### PR TITLE
Add Glance dashboard stack

### DIFF
--- a/roles/karo-compose/defaults/main.yml
+++ b/roles/karo-compose/defaults/main.yml
@@ -20,6 +20,7 @@ karo_compose_stacks_list:
   - seerr
   - jellyfin
   - ntfy
+  - glance
 
 karo_compose_restart_policy: unless-stopped
 karo_compose_timezone: "Europe/London"
@@ -105,6 +106,16 @@ karo_compose_traefik_cetusguard_log_level: 7 # 0-7
 
 # extra stacks
 # ---
+
+# glance
+
+karo_compose_glance_enabled: false
+karo_compose_glance_image: docker.io/glanceapp/glance
+karo_compose_glance_version: v0.8.4@sha256:6df86a7e8868d1eda21f35205134b1962c422957e42a0c44d4717c8e8f741b1a
+karo_compose_glance_domain: "glance.{{ karo_compose_private_domain }}"
+
+karo_compose_glance_config_raw: |
+  # glance config
 
 # gluetun
 

--- a/roles/karo-compose/templates/glance/compose.yml.j2
+++ b/roles/karo-compose/templates/glance/compose.yml.j2
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 hazzuk
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+---
+name: glance
+services:
+
+  glance:
+    # https://github.com/glanceapp/glance
+    # https://hub.docker.com/r/glanceapp/glance
+    image: {{ karo_compose_glance_image }}:{{ karo_compose_glance_version }}
+    container_name: glance
+    restart: {{ karo_compose_restart_policy }}
+    user: 2000:2000
+    tty: false
+    stdin_open: false
+    read_only: true
+    security_opt:
+      - no-new-privileges:true
+    tmpfs:
+    - /tmp:rw,noexec,nosuid,nodev
+    cap_drop:
+      - ALL
+    networks:
+      - egress_glance
+      - frontend
+    volumes:
+      - type: bind
+        source: /etc/localtime
+        target: /etc/localtime
+        read_only: true
+      - type: bind
+        source: /srv/docker/glance/glance.yml
+        target: /app/config/glance.yml
+        read_only: true
+    labels:
+      - traefik.enable=true
+      - traefik.http.routers.glance.rule=Host(`{{ karo_compose_glance_domain }}`)
+      - traefik.http.services.glance.loadbalancer.server.port=8080
+      # forward auth
+      - traefik.http.routers.glance.middlewares=tinyauth
+      - tinyauth.apps.glance.oauth.groups={{ karo_compose_oidc_admin_group }}
+
+networks:
+  egress_glance:
+    name: egress_glance
+    driver: bridge
+    internal: false
+  frontend:
+    external: true
+
+volumes:
+  glance_data:
+    name: glance_data

--- a/roles/karo-compose/templates/glance/glance.yml.j2
+++ b/roles/karo-compose/templates/glance/glance.yml.j2
@@ -1,0 +1,1 @@
+{{ karo_compose_glance_config_raw }}


### PR DESCRIPTION
## Description

Implements Glance to serve as an internal dashboard.

## Notes

- Glance is not designed to be used to monitor the health of other Docker stacks.
- The dashboard is not intended for end-users, only the primary karo-stack admin.
- This is the first stack to implement a full range of Docker security best practices.
- The configuration for Glance will be provided in the karo-docs.
- Closes #17.

## Checklist

- [ ] Written documentation
- [n/a] Linked relevant issues