### PR TITLE
Create proxy stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.ansible
 /.dev
 /inventory
+/cspell.json

--- a/debian/server/d-i/trixie/preseed.cfg
+++ b/debian/server/d-i/trixie/preseed.cfg
@@ -79,7 +79,7 @@ d-i pkgsel/run_tasksel boolean false
 #tasksel tasksel/first multiselect standard
 # example tasksel options: standard, ssh-server, gnome-desktop, kde-desktop, lxqt-desktop, laptop
 ### pkgsel
-d-i pkgsel/include string chrony openssh-server ansible acl python3-debian just parted rsync micro git curl wget btop tree man-db
+d-i pkgsel/include string chrony openssh-server ansible acl python3-debian just parted rsync micro git curl wget btop tree man-db wireguard
 ### disable telemetry
 popularity-contest popularity-contest/participate boolean false
 

--- a/justfile
+++ b/justfile
@@ -87,8 +87,8 @@ setup-password:
 
 # wireguard
 
-# Generate WireGuard key pair
-setup-wireguard:
+# Generate key pair
+wireguard:
     @priv="$(wg genkey)"; \
     pub="$(wg pubkey <<<"$priv")"; \
     printf 'Private key: %s\n' "$priv"; \

--- a/justfile
+++ b/justfile
@@ -2,11 +2,13 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
+
 # help
 
 # Print help
 help:
     @{{ just_executable() }} --list --unsorted --list-prefix "  - " --justfile "{{ justfile() }}"
+
 
 # preseed
 
@@ -30,11 +32,13 @@ _host-preseed platform:
     @echo "info: Press 'Ctrl + C' to exit"
     -python3 -m http.server 8000 --bind 0.0.0.0 --directory ./debian/{{platform}}
 
+
 # server
 
 # Run Ansible to provision the Debian server
 setup-server hostname='': _check-password
     ansible-playbook run.yml --tags setup --limit "{{hostname}}"
+
 
 # compose
 
@@ -47,6 +51,7 @@ setup-compose hostname='' stack='all': _check-password
 [arg("stack", long, short="s")]
 down-compose hostname='' stack='all': _check-password
     ansible-playbook run.yml --extra-vars "karo_compose_justfile_stack={{stack}}" --tags compose --skip-tags deploy,up --limit "{{hostname}}"
+
 
 # vault
 
@@ -78,3 +83,13 @@ _check-password:
 # Edit the Ansible vault password file
 setup-password:
     @micro -backup false -mkparents true "{{password}}"
+
+
+# wireguard
+
+# Generate WireGuard key pair
+setup-wireguard:
+    @priv="$(wg genkey)"; \
+    pub="$(wg pubkey <<<"$priv")"; \
+    printf 'Private key: %s\n' "$priv"; \
+    printf 'Public key: %s\n' "$pub"

--- a/roles/karo-compose/defaults/main.yml
+++ b/roles/karo-compose/defaults/main.yml
@@ -10,9 +10,10 @@ karo_compose_justfile_stack: all
 # docker will stop stacks in reverse order
 karo_compose_stacks:
   core:
-    - pocketid
     - traefik
+    - pocketid
   extra:
+    - proxy
     - whoami
     - godns
     - gluetun
@@ -171,6 +172,21 @@ karo_compose_prowlarr_enabled: false
 karo_compose_prowlarr_image: docker.io/linuxserver/prowlarr
 karo_compose_prowlarr_version: version-2.3.0.5236@sha256:67a8aaedcfd6989f3030b937a6a07007310b1dfc7ee8df16d2cbfa48d1c1158c
 karo_compose_prowlarr_domain: "prowlarr.{{ karo_compose_private_domain }}"
+
+# proxy
+
+karo_compose_proxy_client_enabled: false
+karo_compose_proxy_server_enabled: false
+
+karo_compose_proxy_enabled: "{{ karo_compose_proxy_server_enabled }}"
+
+# proxy haproxy
+
+karo_compose_proxy_haproxy_image: docker.io/haproxy
+karo_compose_proxy_haproxy_version: 3.2.15-alpine@sha256:6af70a17d18cc5a907cf1299322cd12f4cc2546f73c7fa8620e6f7029dbcc5e6
+
+karo_compose_proxy_haproxy_config_raw: |
+  # haproxy config
 
 # qbittorrent
 

--- a/roles/karo-compose/defaults/main.yml
+++ b/roles/karo-compose/defaults/main.yml
@@ -183,6 +183,8 @@ karo_compose_proxy_enabled: "{{ karo_compose_proxy_server_enabled }}"
 karo_compose_proxy_client_wireguard_ipv4: 10.25.0.2
 karo_compose_proxy_server_wireguard_ipv4: 10.25.0.1
 
+karo_compose_proxy_server_wireguard_port: 52525
+
 # proxy haproxy
 
 karo_compose_proxy_haproxy_image: docker.io/haproxy

--- a/roles/karo-compose/defaults/main.yml
+++ b/roles/karo-compose/defaults/main.yml
@@ -180,6 +180,9 @@ karo_compose_proxy_server_enabled: false
 
 karo_compose_proxy_enabled: "{{ karo_compose_proxy_server_enabled }}"
 
+karo_compose_proxy_client_wireguard_ipv4: 10.25.0.2
+karo_compose_proxy_server_wireguard_ipv4: 10.25.0.1
+
 # proxy haproxy
 
 karo_compose_proxy_haproxy_image: docker.io/haproxy

--- a/roles/karo-compose/defaults/main.yml
+++ b/roles/karo-compose/defaults/main.yml
@@ -188,7 +188,7 @@ karo_compose_proxy_server_wireguard_port: 52525
 # proxy haproxy
 
 karo_compose_proxy_haproxy_image: docker.io/haproxy
-karo_compose_proxy_haproxy_version: 3.2.15-alpine@sha256:6af70a17d18cc5a907cf1299322cd12f4cc2546f73c7fa8620e6f7029dbcc5e6
+karo_compose_proxy_haproxy_version: 3.2.17-alpine@sha256:0c32ec9e64a3bbacb2a1a28afbc3d46032d905bf74ccb745b45488ff41ee9a6b
 
 karo_compose_proxy_haproxy_config_raw: |
   # haproxy config

--- a/roles/karo-compose/templates/core/traefik/traefik.yml.j2
+++ b/roles/karo-compose/templates/core/traefik/traefik.yml.j2
@@ -31,6 +31,11 @@ entryPoints:
     address: :443
     http3: true
     asDefault: true
+{% if karo_compose_proxy_client_enabled %}
+    proxyProtocol:
+      trustedIPs:
+        - "{{ karo_compose_proxy_server_wireguard_ipv4 }}"
+{% endif %}
     http:
       tls:
         certResolver: cloudflare

--- a/roles/karo-compose/templates/extra/proxy/compose.yml.j2
+++ b/roles/karo-compose/templates/extra/proxy/compose.yml.j2
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 hazzuk
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+# https://docs.karolabs.dev/stacks/extra/proxy
+
+---
+name: proxy
+services:
+
+  haproxy:
+    image: {{ karo_compose_proxy_haproxy_image }}:{{ karo_compose_proxy_haproxy_version }}
+    container_name: haproxy
+    restart: {{ karo_compose_restart_policy }}
+    ports:
+      - "0.0.0.0:80:80/tcp"
+      - "0.0.0.0:443:443/tcp"
+    networks:
+      - egress_haproxy
+    volumes:
+      - type: bind
+        source: /srv/docker/extra/proxy/haproxy.cfg
+        target: /usr/local/etc/haproxy/haproxy.cfg
+        read_only: true
+
+networks:
+  egress_haproxy:
+    name: egress_haproxy
+    driver: bridge
+    internal: false

--- a/roles/karo-compose/templates/extra/proxy/haproxy.cfg.j2
+++ b/roles/karo-compose/templates/extra/proxy/haproxy.cfg.j2
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: 2026 hazzuk
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+
+global
+  log stdout format raw local0
+  stats timeout 30s
+
+defaults
+  # logging
+  log global
+  option dontlognull
+  option tcplog
+
+  # connections
+  option tcpka
+  option tcp-smart-accept
+  option tcp-smart-connect
+
+  # timeouts
+  timeout connect 10s
+  timeout client  1m
+  timeout server  1m
+
+frontend http
+  bind *:80
+  mode http
+
+  # https redirect
+  http-request redirect scheme https code 301 if !{ ssl_fc }
+
+frontend https
+  bind *:443
+  mode tcp
+
+  # wait for tls clienthello
+  tcp-request inspect-delay 5s
+  tcp-request content accept if { req_ssl_hello_type 1 }
+  tcp-request content reject
+
+  {{ karo_compose_proxy_haproxy_config_raw }}

--- a/roles/karo-compose/templates/extra/proxy/haproxy.cfg.j2
+++ b/roles/karo-compose/templates/extra/proxy/haproxy.cfg.j2
@@ -34,9 +34,4 @@ frontend https
   bind *:443
   mode tcp
 
-  # wait for tls clienthello
-  tcp-request inspect-delay 5s
-  tcp-request content accept if { req_ssl_hello_type 1 }
-  tcp-request content reject
-
   {{ karo_compose_proxy_haproxy_config_raw }}

--- a/roles/karo-compose/templates/extra/proxy/haproxy.cfg.j2
+++ b/roles/karo-compose/templates/extra/proxy/haproxy.cfg.j2
@@ -20,8 +20,10 @@ defaults
 
   # timeouts
   timeout connect 10s
-  timeout client  1m
-  timeout server  1m
+  timeout check   10s
+  timeout client  30s
+  timeout server  30s
+  timeout tunnel  1h
 
 frontend http
   bind *:80

--- a/roles/karo-docker/tasks/rootless.yml
+++ b/roles/karo-docker/tasks/rootless.yml
@@ -106,13 +106,6 @@
     state: started
     daemon_reload: true
 
-- name: Allow rootless exposing privileged ports
-  community.general.capabilities:
-    capability: cap_net_bind_service=ep
-    path: /usr/bin/rootlesskit
-    state: present
-  notify: Restart rootless docker
-
 - name: Create docker compose directory
   ansible.builtin.file:
     path: /srv/docker

--- a/roles/karo-nftables/defaults/main.yml
+++ b/roles/karo-nftables/defaults/main.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 hazzuk
+# SPDX-FileCopyrightText: 2026 hazzuk
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -9,3 +9,9 @@ karo_nftables_accepted_tcp_ports: "" # e.g. "53, 465, 587"
 
 # udp port 443 is allowed by default (server only)
 karo_nftables_accepted_udp_ports: "" # e.g. "7777, 25565"
+
+# allow icmp traffic (pings)
+karo_nftables_icmp_enabled: false
+
+# log denied traffic (sudo journalctl -k -f)
+karo_nftables_log_enabled: false

--- a/roles/karo-nftables/templates/nftables.conf.j2
+++ b/roles/karo-nftables/templates/nftables.conf.j2
@@ -36,6 +36,29 @@ table inet filter {
                 tcp dport { 80, 443 } accept
                 udp dport 443 accept
 {% endif %}
+
+{% if karo_compose_jellyfin_enabled | default(false) %}
+
+                # allow jellyfin discovery port
+                udp dport 7359 accept
+{% endif %}
+{% if karo_compose_proxy_client_enabled | default(false) %}
+
+                # allow wireguard proxyserver traffic
+                iif "wg0" ip saddr {{ karo_compose_proxy_server_wireguard_ipv4 }} tcp dport { 80, 443 } accept
+
+                # allow proxyserver pings
+                ip protocol icmp ip saddr {{ karo_compose_proxy_server_wireguard_ipv4 }} accept
+{% endif %}
+{% if karo_compose_proxy_server_enabled | default(false) %}
+
+                # allow wireguard listen port
+                udp dport {{ karo_compose_proxy_server_wireguard_port }} accept
+
+                # allow homeserver pings
+                ip protocol icmp ip saddr {{ karo_compose_proxy_client_wireguard_ipv4 }} accept
+{% endif %}
+
 {% if karo_nftables_accepted_tcp_ports %}
 
                 # allow user defined tcp connections

--- a/roles/karo-nftables/templates/nftables.conf.j2
+++ b/roles/karo-nftables/templates/nftables.conf.j2
@@ -45,7 +45,7 @@ table inet filter {
 {% if karo_compose_proxy_client_enabled | default(false) %}
 
                 # allow wireguard proxyserver traffic
-                iif "wg0" ip saddr {{ karo_compose_proxy_server_wireguard_ipv4 | default('10.25.0.1') }} tcp dport { 80, 443 } accept
+                ip saddr {{ karo_compose_proxy_server_wireguard_ipv4 | default('10.25.0.1') }} tcp dport { 80, 443 } accept
 
                 # allow proxyserver pings
                 ip protocol icmp ip saddr {{ karo_compose_proxy_server_wireguard_ipv4 | default('10.25.0.1') }} accept

--- a/roles/karo-nftables/templates/nftables.conf.j2
+++ b/roles/karo-nftables/templates/nftables.conf.j2
@@ -1,6 +1,6 @@
 #!/usr/sbin/nft -f
 
-# SPDX-FileCopyrightText: 2025 hazzuk
+# SPDX-FileCopyrightText: 2026 hazzuk
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -16,32 +16,32 @@ table inet filter {
                 # criteria specified by the rules that follow below
                 type filter hook input priority filter; policy drop;
 
-                # allow loopback traffic
-                iifname "lo" accept
+                # allow localhost loopback traffic
+                iif lo accept
 
                 # allow traffic from established and related packets, drop invalid
                 ct state established,related accept
                 ct state invalid drop
 
-                # allow new or established ssh connections
-                tcp dport {{ karo_ssh_port | default(22) }} ct state new,established accept
-
+                # allow new ssh connections
+                tcp dport {{ karo_ssh_port | default(22) }} accept
 {% if 'server' in group_names %}
-                # allow new or established http/https/http3 connections
-                tcp dport { 80, 443 } ct state new,established accept
-                udp dport 443 ct state new,established accept
 
+                # allow new http/https/http3 connections
+                tcp dport { 80, 443 } accept
+                udp dport 443 accept
 {% endif %}
 {% if karo_nftables_accepted_tcp_ports %}
-                # allow user defined tcp connections
-                tcp dport { {{ karo_nftables_accepted_tcp_ports }} } ct state new,established accept
 
+                # allow user defined tcp connections
+                tcp dport { {{ karo_nftables_accepted_tcp_ports }} } accept
 {% endif %}
 {% if karo_nftables_accepted_udp_ports %}
-                # allow user defined udp connections
-                udp dport { {{ karo_nftables_accepted_udp_ports }} } ct state new,established accept
 
+                # allow user defined udp connections
+                udp dport { {{ karo_nftables_accepted_udp_ports }} } accept
 {% endif %}
+
                 # uncomment to enable logging of denied inbound traffic
                 # log prefix "[nftables] Inbound Denied: " counter drop
         }

--- a/roles/karo-nftables/templates/nftables.conf.j2
+++ b/roles/karo-nftables/templates/nftables.conf.j2
@@ -45,18 +45,18 @@ table inet filter {
 {% if karo_compose_proxy_client_enabled | default(false) %}
 
                 # allow wireguard proxyserver traffic
-                iif "wg0" ip saddr {{ karo_compose_proxy_server_wireguard_ipv4 }} tcp dport { 80, 443 } accept
+                iif "wg0" ip saddr {{ karo_compose_proxy_server_wireguard_ipv4 | default('10.25.0.1') }} tcp dport { 80, 443 } accept
 
                 # allow proxyserver pings
-                ip protocol icmp ip saddr {{ karo_compose_proxy_server_wireguard_ipv4 }} accept
+                ip protocol icmp ip saddr {{ karo_compose_proxy_server_wireguard_ipv4 | default('10.25.0.1') }} accept
 {% endif %}
 {% if karo_compose_proxy_server_enabled | default(false) %}
 
                 # allow wireguard listen port
-                udp dport {{ karo_compose_proxy_server_wireguard_port }} accept
+                udp dport {{ karo_compose_proxy_server_wireguard_port | default('52525') }} accept
 
                 # allow homeserver pings
-                ip protocol icmp ip saddr {{ karo_compose_proxy_client_wireguard_ipv4 }} accept
+                ip protocol icmp ip saddr {{ karo_compose_proxy_client_wireguard_ipv4 | default('10.25.0.2') }} accept
 {% endif %}
 
 {% if karo_nftables_accepted_tcp_ports %}

--- a/roles/karo-nftables/templates/nftables.conf.j2
+++ b/roles/karo-nftables/templates/nftables.conf.j2
@@ -22,6 +22,11 @@ table inet filter {
                 # allow traffic from established and related packets, drop invalid
                 ct state established,related accept
                 ct state invalid drop
+{% if karo_nftables_icmp_enabled %}
+
+                # allow icmp traffic
+                ip protocol icmp accept
+{% endif %}
 
                 # allow new ssh connections
                 tcp dport {{ karo_ssh_port | default(22) }} accept
@@ -42,8 +47,10 @@ table inet filter {
                 udp dport { {{ karo_nftables_accepted_udp_ports }} } accept
 {% endif %}
 
-                # uncomment to enable logging of denied inbound traffic
-                # log prefix "[nftables] Inbound Denied: " counter drop
+{% if karo_nftables_log_enabled %}
+                # debug denied traffic 
+                log prefix "nftables: input denied: " counter drop
+{% endif %}
         }
         chain forward {
                 type filter hook forward priority filter; policy drop;

--- a/roles/karo-system/defaults/main.yml
+++ b/roles/karo-system/defaults/main.yml
@@ -17,6 +17,7 @@ karo_system_packages:
   - btop
   - tree
   - man-db
+  - wireguard
 
 karo_system_motd_raw: |
    _                           _             _    

--- a/roles/karo-system/files/sysctl_karo.conf
+++ b/roles/karo-system/files/sysctl_karo.conf
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2025 hazzuk
+# SPDX-FileCopyrightText: 2026 hazzuk
 #
 # SPDX-License-Identifier: AGPL-3.0-only
 
@@ -10,3 +10,6 @@ net.ipv4.ip_forward=1
 # https://github.com/quic-go/quic-go/wiki/UDP-Buffer-Sizes
 net.core.rmem_max=7500000
 net.core.wmem_max=7500000
+
+# allow exposing privileged ports for rootless docker
+net.ipv4.ip_unprivileged_port_start=0


### PR DESCRIPTION
## Description

This PR adds a new custom stack, named **proxy**. The proxy stack's use is to setup a secondary server you'd rent in the cloud. Your VPS would then tunnel traffic into your home network safely, without exposing your public IP address or the need for port forwarding.

This is the first of multiple pull requests. Future PR's will add a firewall, and include a declarative WireGuard setup.

## Changes

- Created the new proxy stack (currently consisting of HAProxy and its configuration file)
- Configure Traefik to allow proxy protocol headers
- Include the WireGuard system package
- New Justfile recipe for WireGuard keys generation 
- Refactor allowing exposure of privileged ports
- Overhaul of the nftables firewall config

## Notes

- Currently WireGuard has to be manually configured on both hosts.
- For now, both the homeserver and proxyserver require a different Docker network/port driver to propagate source IP addresses of incoming traffic. This should change once Docker updates to include v3.0.0 of [RootlessKit](https://github.com/rootless-containers/rootlesskit) (which now adds support for this with the builtin port driver).

## Checklist

- [x] Written documentation
- [n/a] Linked relevant issues
