### PR TITLE
Justfile refactor

### DIFF
--- a/justfile
+++ b/justfile
@@ -12,8 +12,8 @@ help:
 
 # preseed
 
-# Host the Debian preseed.cfg file for use over a local network
-@preseed-server:
+# Host preseed.cfg
+@preseed:
     # check user key file exists
     [ -e "inventory/key.txt" ] || { echo "error: inventory/key.txt not found!" >&2; exit 1; }
     # insert public ssh key into preseed file
@@ -35,14 +35,14 @@ _host-preseed platform:
 
 # server
 
-# Run Ansible to provision the Debian server
-setup-server hostname='': _check-password
+# Setup a system
+@install hostname='': _check-password
     ansible-playbook run.yml --tags setup --limit "{{hostname}}"
 
 
 # compose
 
-# Run Ansible to deploy Docker compose stacks
+# Deploy/remove stacks
 [arg("stack", long, short="s")]
 setup-compose hostname='' stack='all': _check-password
     ansible-playbook run.yml --extra-vars "karo_compose_justfile_stack={{stack}}" --tags compose --skip-tags down --limit "{{hostname}}"
@@ -57,8 +57,8 @@ down-compose hostname='' stack='all': _check-password
 
 password := "/run/user/1000/karo-stack/vault_pass"
 
-# Manage an Ansible vault
-setup-vault hostname:
+# Manage a vault
+vault hostname:
     #!/bin/bash
     # check password file exists
     if [ -e "{{password}}" ]; then
@@ -80,8 +80,8 @@ setup-vault hostname:
 _check-password:
     @[ -e "{{password}}" ] || micro -backup false -mkparents true "{{password}}"
 
-# Edit the Ansible vault password file
-setup-password:
+# Set password
+password:
     @micro -backup false -mkparents true "{{password}}"
 
 

--- a/justfile
+++ b/justfile
@@ -15,7 +15,7 @@ help:
 # Host preseed.cfg
 @preseed:
     # check user key file exists
-    [ -e "inventory/key.txt" ] || { echo "error: inventory/key.txt not found!" >&2; exit 1; }
+    [ -e "inventory/key.txt" ] || { echo "inventory/key.txt not found" >&2; exit 1; }
     # insert public ssh key into preseed file
     just _insert-preseed-key "$(cat inventory/key.txt)" server
     # run webserver
@@ -29,7 +29,7 @@ _insert-preseed-key value platform:
 
 # (Internal use) Run a Python HTTP server to host the preseed file
 _host-preseed platform:
-    @echo "info: Press 'Ctrl + C' to exit"
+    @echo "press 'Ctrl + C' to exit"
     -python3 -m http.server 8000 --bind 0.0.0.0 --directory ./debian/{{platform}}
 
 
@@ -72,8 +72,7 @@ vault hostname:
             ansible-vault create "$vault"
         fi
     else
-        echo "error: {{password}} not found! Run 'just setup-password'" >&2
-        exit 1
+        echo "{{password}} not found, run 'just password'." >&2; exit 1;
     fi
 
 # (Internal use) Create the Ansible vault password file when missing

--- a/justfile
+++ b/justfile
@@ -46,13 +46,22 @@ _host-preseed platform:
 
 # Deploy/remove stacks
 [arg("stack", long, short="s")]
-setup-compose hostname='' stack='all': _check-password
-    ansible-playbook run.yml --extra-vars "karo_compose_justfile_stack={{stack}}" --tags compose --skip-tags down --limit "{{hostname}}"
-
-# Run Ansible to down Docker compose stacks
-[arg("stack", long, short="s")]
-down-compose hostname='' stack='all': _check-password
-    ansible-playbook run.yml --extra-vars "karo_compose_justfile_stack={{stack}}" --tags compose --skip-tags deploy,up --limit "{{hostname}}"
+compose action hostname='' stack='all': _check-password
+    #!/bin/bash
+    # check user input for action
+    if [ "{{action}}" = "up" ]; then
+        skip_tags="down"
+    elif [ "{{action}}" = "down" ]; then
+        skip_tags="deploy,up"
+    else
+        echo "action must be 'up' or 'down'" >&2; exit 1;
+    fi
+    # run user action
+    ansible-playbook run.yml \
+        --extra-vars "karo_compose_justfile_stack={{stack}}" \
+        --tags compose \
+        --skip-tags "$skip_tags" \
+        --limit "{{hostname}}"
 
 
 # vault

--- a/justfile
+++ b/justfile
@@ -13,15 +13,17 @@ help:
 # preseed
 
 # Host preseed.cfg
-@preseed:
+@preseed platform='server':
+    # check user input for platform
+    [ "{{platform}}" = "server" ] || [ "{{platform}}" = "desktop" ] || { echo "platform must be 'server' or 'desktop'" >&2; exit 1; }
     # check user key file exists
     [ -e "inventory/key.txt" ] || { echo "inventory/key.txt not found" >&2; exit 1; }
     # insert public ssh key into preseed file
-    just _insert-preseed-key "$(cat inventory/key.txt)" server
+    just _insert-preseed-key "$(cat inventory/key.txt)" {{platform}}
     # run webserver
-    -just _host-preseed server
+    -just _host-preseed {{platform}}
     -# revert change to preseed file
-    -just _insert-preseed-key "<key>" server
+    -just _insert-preseed-key "<key>" {{platform}}
 
 # (Internal use) Write the authorized SSH key to the Debian preseed file
 _insert-preseed-key value platform:


### PR DESCRIPTION
## Description

This PR hugely simplifies the naming of the justfile recipes, making it far easier to learn and use each command.

## Changes

Whilst recipes might have previously been easier to verbalise. They were confusingly similar (most prefixed with the term 'setup') and were wordier, being harder to remember. This PR changes that:

```
just preseed-server         ->    just preseed -p
just setup-server -h        ->    just install -h
just setup-wireguard        ->    just wireguard

just setup-compose -h -s    ->    just compose up -h -s 
just down-compose -h -s     ->    just compose down -h -s 

just setup-vault -h         ->    just vault -h
just setup-password         ->    just password
```

Additional changes have been made to accommodate the new simpler recipes.

## Checklist

- [x] Written documentation
- [n/a] Linked relevant issues
