### PR TITLE
Propagate source IP in Docker

### DIFF
--- a/roles/karo-docker/files/daemon.json
+++ b/roles/karo-docker/files/daemon.json
@@ -23,5 +23,6 @@
             "size": 24
         }
     ],
-    "firewall-backend": "nftables"
+    "firewall-backend": "nftables",
+    "userland-proxy": false
 }

--- a/roles/karo-docker/handlers/main.yml
+++ b/roles/karo-docker/handlers/main.yml
@@ -4,10 +4,12 @@
 
 ---
 
-- name: Restart rootless docker
+- name: Restart rootless docker service
   become: true
   become_user: dockeruser
   ansible.builtin.systemd_service:
-    name: docker
+    name: docker.service
     scope: user
+    enabled: true
     state: restarted
+    daemon_reload: true

--- a/roles/karo-docker/tasks/rootless.yml
+++ b/roles/karo-docker/tasks/rootless.yml
@@ -83,6 +83,7 @@
         mode: "0644"
         owner: dockeruser
         group: dockeruser
+      notify: Restart rootless docker service
 
 - name: Install rootless docker
   become: true
@@ -95,16 +96,6 @@
       - /usr/bin/dockerd-rootless-setuptool.sh
       - install
     creates: /run/user/1001/docker.sock
-
-- name: Enable rootless docker service
-  become: true
-  become_user: dockeruser
-  ansible.builtin.systemd_service:
-    name: docker.service
-    scope: user
-    enabled: true
-    state: started
-    daemon_reload: true
 
 - name: Create docker compose directory
   ansible.builtin.file:

--- a/roles/karo-system/files/modules_karo.conf
+++ b/roles/karo-system/files/modules_karo.conf
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2026 hazzuk
+#
+# SPDX-License-Identifier: AGPL-3.0-only
+
+
+# required to disable docker userland proxy
+br_netfilter

--- a/roles/karo-system/handlers/main.yml
+++ b/roles/karo-system/handlers/main.yml
@@ -8,6 +8,11 @@
   ansible.builtin.systemd_service:
     daemon_reload: true
 
+- name: Restart systemd-modules-load
+  ansible.builtin.systemd_service:
+    name: systemd-modules-load.service
+    state: restarted
+
 - name: Reload sysctl config
   ansible.builtin.command:
     argv:

--- a/roles/karo-system/tasks/main.yml
+++ b/roles/karo-system/tasks/main.yml
@@ -29,6 +29,13 @@
     mode: "0644"
   notify: Reload sysctl config
 
+- name: Load kernel modules
+  ansible.builtin.copy:
+    src: modules_karo.conf
+    dest: /etc/modules-load.d/karo.conf
+    mode: "0644"
+  notify: Restart systemd-modules-load
+
 - name: Set bash configuration for karo
   ansible.builtin.copy:
     src: "{{ item }}"


### PR DESCRIPTION
## Description

This PR makes the necessary changes to propagate source IP addresses in rootless Docker.

(For Docker v29.5.0, introduced in [RootlessKit v3.0.0](https://github.com/rootless-containers/rootlesskit/releases/tag/v3.0.0))

## Changes

- Disable Docker `userland-proxy`
- New Ansible handler for Docker `daemon.json` changes
- Load `br_netfilter` kernel module
- New Ansible task for loading kernel modules

## Notes

- Based on [Docker's documentation](https://docs.docker.com/engine/security/rootless/troubleshoot/#docker-run--p-does-not-propagate-source-ip-addresses).

- Previously, it was required to use alternative [network](https://github.com/rootless-containers/rootlesskit/blob/master/docs/network.md) and [port](https://github.com/rootless-containers/rootlesskit/blob/master/docs/port.md) drivers:

    ```sh
    mkdir /home/dockeruser/.config/systemd/user/docker.service.d/
    micro /home/dockeruser/.config/systemd/user/docker.service.d/override.conf
    
    # [Service]
    # Environment="DOCKERD_ROOTLESS_ROOTLESSKIT_NET=pasta"
    # Environment="DOCKERD_ROOTLESS_ROOTLESSKIT_PORT_DRIVER=implicit"
    
    systemctl --user daemon-reload && systemctl --user restart docker
    ```

- While alternative drivers may offer more features or performance. The karo-stack should avoid changing defaults where possible to ensure better stability.

## Checklist

- [n/a] Written documentation
- [n/a] Linked relevant issues
