### PR TITLE
Configure system hostname

### DIFF
--- a/roles/karo-system/tasks/main.yml
+++ b/roles/karo-system/tasks/main.yml
@@ -40,6 +40,17 @@
     - bash_logout
     - profile
 
+- name: Add hostname to hosts
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    regexp: '^127\.0\.1\.1\s+debian(\s+{{ inventory_hostname }})?$'
+    line: "127.0.1.1 debian {{ inventory_hostname }}"
+
+- name: Set system hostname
+  ansible.builtin.hostname:
+    name: "{{ inventory_hostname }}"
+    use: systemd
+
 - name: Set motd
   ansible.builtin.copy:
     content: "{{ karo_system_motd_raw }}"


### PR DESCRIPTION
## Description

This PR sets the system hostname to the Ansible inventory hostname.

## Changes

Added two new Ansible tasks:

- Edit hosts file to include hostname (the hostname needs to be able to resolve itself)
- Set system hostname using systemd (akin to running `hostnamectl set-hostname homeserver`)

## Notes

- The hostname is stored in `/etc/hostname`
- [Debian hostname resolution docs](https://www.debian.org/doc/manuals/debian-reference/ch05.en.html#_the_hostname_resolution)

## Checklist

- [n/a] Written documentation
- [n/a] Linked relevant issues
