### PR TITLE
Compose role rework

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,7 +6,7 @@ local_tmp = /run/user/1000/karo/ansible/tmp
 editor = micro -backup false
 
 [privilege_escalation]
-become_ask_pass = true
+become_ask_pass = false
 
 [ssh_connection]
 pipelining = true

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,8 +1,8 @@
 [defaults]
 inventory = inventory/hosts.ini
 interpreter_python = /usr/bin/python3
-vault_password_file = /run/user/1000/karo-stack/vault_pass
-local_tmp = /run/user/1000/karo-stack/ansible-tmp
+vault_password_file = /run/user/1000/karo/ansible/vault_pass
+local_tmp = /run/user/1000/karo/ansible/tmp
 editor = micro -backup false
 
 [privilege_escalation]

--- a/justfile
+++ b/justfile
@@ -66,7 +66,7 @@ compose action hostname='' stack='all': _check-password
 
 # vault
 
-password := "/run/user/1000/karo-stack/vault_pass"
+password := "/run/user/1000/karo/ansible/vault_pass"
 
 # Manage a vault
 vault hostname:

--- a/justfile
+++ b/justfile
@@ -57,7 +57,7 @@ compose action hostname='' stack='all': _check-password
         echo "action must be 'up' or 'down'" >&2; exit 1;
     fi
     # run user action
-    ansible-playbook run.yml \
+    ANSIBLE_DISPLAY_SKIPPED_HOSTS=false ansible-playbook run.yml \
         --extra-vars "karo_compose_justfile_stack={{stack}}" \
         --tags compose \
         --skip-tags "$skip_tags" \

--- a/roles/karo-compose/defaults/main.yml
+++ b/roles/karo-compose/defaults/main.yml
@@ -69,8 +69,9 @@ karo_compose_pocketid_image: ghcr.io/pocket-id/pocket-id
 karo_compose_pocketid_version: v2.6.2@sha256:1cc51e5b36fa7ec31368d3efb24ba362be6dce20f3cc0a2852843527bd5110f0
 karo_compose_pocketid_log_level: info # debug, info, warn, error
 
-karo_compose_pocketid_encryption_key: "" # secret (`openssl rand -base64 32`)
-karo_compose_pocketid_maxmind_license_key: "" # secret
+karo_compose_pocketid_secrets:
+  pocketid_encryption_key: "" # `openssl rand -base64 32`
+  pocketid_maxmind_license_key: ""
 
 # traefik
 
@@ -92,8 +93,11 @@ karo_compose_traefik_acme_ca_server_url: "https://acme-v02.api.letsencrypt.org/d
 karo_compose_traefik_acme_staging_ca_server_url: "https://acme-staging-v02.api.letsencrypt.org/directory"
 
 karo_compose_traefik_acme_email: cert@example.com
-karo_compose_traefik_acme_zone_api_token: "" # secret
-karo_compose_traefik_acme_dns_api_token: "" # secret
+
+karo_compose_traefik_secrets:
+  traefik_acme_zone_api_token: ""
+  traefik_acme_dns_api_token: ""
+  tinyauth_oidc_client_secret: ""
 
 # traefik tinyauth
 
@@ -103,7 +107,6 @@ karo_compose_traefik_tinyauth_domain: "tinyauth.{{ karo_compose_root_domain }}"
 karo_compose_traefik_tinyauth_log_level: info # trace, debug, info, warn, error, fatal, panic
 
 karo_compose_traefik_tinyauth_oidc_client_id: ""
-karo_compose_traefik_tinyauth_oidc_client_secret: "" # secret
 
 # traefik cetusguard
 
@@ -134,8 +137,9 @@ karo_compose_gluetun_log_level: info # debug, info, warning, error
 
 karo_compose_gluetun_firewall_vpn_input_ports: ""
 
-karo_compose_gluetun_wireguard_config_raw: | # secret
-  # wireguard config
+karo_compose_gluetun_secrets:
+  gluetun_wireguard_config_raw: |
+    # wireguard config
 
 # godns
 
@@ -146,7 +150,8 @@ karo_compose_godns_debug_info_enabled: false
 
 karo_compose_godns_subdomain: home
 
-karo_compose_godns_dns_api_token: "" # secret
+karo_compose_godns_secrets:
+  godns_dns_api_token: ""
 
 # jellyfin
 
@@ -209,6 +214,10 @@ karo_compose_qbittorrent_downloads_path: "" # e.g. /media/drive1/data/torrents
 
 karo_compose_qbittorrent_webui_enabled: true
 
+karo_compose_qbittorrent_secrets:
+  qui_session_secret: "" # `openssl rand -hex 16`
+  qui_oidc_client_secret: ""
+
 # qbittorrent qui
 
 karo_compose_qbittorrent_qui_image: ghcr.io/autobrr/qui
@@ -216,10 +225,7 @@ karo_compose_qbittorrent_qui_version: v1.17.0@sha256:fb3832e68f66b056e1b049d16c4
 karo_compose_qbittorrent_qui_domain: "qui.{{ karo_compose_root_domain }}"
 karo_compose_qbittorrent_qui_log_level: info # trace, debug, info, warn, error
 
-karo_compose_qbittorrent_qui_session_secret: "" # secret (`openssl rand -hex 16`)
-
 karo_compose_qbittorrent_qui_oidc_client_id: ""
-karo_compose_qbittorrent_qui_oidc_client_secret: "" # secret
 
 # radarr
 

--- a/roles/karo-compose/tasks/deploy.yml
+++ b/roles/karo-compose/tasks/deploy.yml
@@ -5,22 +5,16 @@
 ---
 
 - name: "Create compose stack directory for {{ stack }}"
-  tags: deploy
   ansible.builtin.file:
     path: "/srv/docker/{{ group }}/{{ stack }}"
     mode: "0774"
-    owner: dockeruser
-    group: dockeruser
     state: directory
 
 - name: "Deploy compose templates for {{ stack }}"
-  tags: deploy
   ansible.builtin.template:
     src: "{{ template.src }}"
     dest: "/srv/docker/{{ group }}/{{ stack }}/{{ template.path | splitext | first }}"
     mode: "0644"
-    owner: dockeruser
-    group: dockeruser
   loop_control:
     loop_var: template
     label: "{{ template.path }}"

--- a/roles/karo-compose/tasks/deploy.yml
+++ b/roles/karo-compose/tasks/deploy.yml
@@ -23,4 +23,5 @@
     group: dockeruser
   loop_control:
     loop_var: template
+    label: "{{ template.path }}"
   with_community.general.filetree: ../templates/{{ group }}/{{ stack }}/

--- a/roles/karo-compose/tasks/down.yml
+++ b/roles/karo-compose/tasks/down.yml
@@ -5,9 +5,6 @@
 ---
 
 - name: Down compose stack {{ stack }}
-  become: true
-  become_user: dockeruser
-  tags: down
   community.docker.docker_compose_v2:
     docker_host: unix:///run/user/1001/docker.sock
     project_src: "/srv/docker/{{ group }}/{{ stack }}"

--- a/roles/karo-compose/tasks/main.yml
+++ b/roles/karo-compose/tasks/main.yml
@@ -6,6 +6,17 @@
 
 ---
 
+- name: Check docker directory status
+  ansible.builtin.stat:
+    path: /srv/docker
+  register: docker_dir
+
+- name: Assert docker setup
+  ansible.builtin.assert:
+    that: docker_dir.stat.exists
+    fail_msg: "Docker directory not present, run `just install` to setup Docker."
+    quiet: true
+
 - name: Define expanded stack list
   ansible.builtin.set_fact:
     karo_compose_stacks_expanded: >-
@@ -18,6 +29,15 @@
   loop: "{{ karo_compose_stacks | dict2items | subelements('value') }}"
   loop_control:
     label: "{{ item.0.key }}/{{ item.1 }}"
+
+- name: Assert stack name
+  ansible.builtin.assert:
+    that: karo_compose_justfile_stack in (
+        karo_compose_stacks_expanded | map(attribute='name') | list
+        + ['all']
+      )
+    fail_msg: "Invalid stack name '{{ karo_compose_justfile_stack }}'."
+    quiet: true
 
 - name: Down stacks
   become: true

--- a/roles/karo-compose/tasks/main.yml
+++ b/roles/karo-compose/tasks/main.yml
@@ -34,7 +34,7 @@
         group: "{{ item.group }}"
       when:
         - lookup('vars', 'karo_compose_' ~ stack ~ '_enabled') | default(false)
-        - stack == karo_compose_justfile_stack or karo_compose_justfile_stack == 'all'
+        - karo_compose_justfile_stack in [stack, 'all']
 
 - name: Deploy stacks
   become: true
@@ -51,7 +51,7 @@
         group: "{{ item.group }}"
       when:
         - lookup('vars', 'karo_compose_' ~ stack ~ '_enabled') | default(false)
-        - stack == karo_compose_justfile_stack or karo_compose_justfile_stack == 'all'
+        - karo_compose_justfile_stack in [stack, 'all']
 
 - name: Create stacks
   become: true
@@ -75,7 +75,7 @@
         secrets: "{{ lookup('vars', 'karo_compose_' ~ stack ~ '_secrets', default={}) | dict2items }}"
       when:
         - lookup('vars', 'karo_compose_' ~ stack ~ '_enabled') | default(false)
-        - stack == karo_compose_justfile_stack or karo_compose_justfile_stack == 'all'
+        - karo_compose_justfile_stack in [stack, 'all']
 
   always:
     - name: Discard tmpfs secrets directory

--- a/roles/karo-compose/tasks/main.yml
+++ b/roles/karo-compose/tasks/main.yml
@@ -97,3 +97,4 @@
         path: "/run/user/1001/karo/compose"
         state: absent
       when: secrets_dir | default(false)
+      changed_when: false

--- a/roles/karo-compose/tasks/main.yml
+++ b/roles/karo-compose/tasks/main.yml
@@ -7,7 +7,6 @@
 ---
 
 - name: Define expanded stack list
-  no_log: true
   ansible.builtin.set_fact:
     karo_compose_stacks_expanded: >-
       {{ karo_compose_stacks_expanded | default([]) + [
@@ -17,10 +16,14 @@
         }
       ] }}
   loop: "{{ karo_compose_stacks | dict2items | subelements('value') }}"
+  loop_control:
+    label: "{{ item.0.key }}/{{ item.1 }}"
 
 - name: Down docker compose stacks
   ansible.builtin.include_tasks: down.yml
   loop: "{{ karo_compose_stacks_expanded | reverse }}"
+  loop_control:
+    label: "{{ item.name }}"
   vars:
     stack: "{{ item.name }}"
     group: "{{ item.group }}"
@@ -32,6 +35,8 @@
 - name: Deploy compose stacks
   ansible.builtin.include_tasks: deploy.yml
   loop: "{{ karo_compose_stacks_expanded }}"
+  loop_control:
+    label: "{{ item.name }}"
   vars:
     stack: "{{ item.name }}"
     group: "{{ item.group }}"
@@ -54,6 +59,8 @@
     - name: Up docker compose stacks
       ansible.builtin.include_tasks: up.yml
       loop: "{{ karo_compose_stacks_expanded }}"
+      loop_control:
+        label: "{{ item.name }}"
       vars:
         stack: "{{ item.name }}"
         group: "{{ item.group }}"

--- a/roles/karo-compose/tasks/main.yml
+++ b/roles/karo-compose/tasks/main.yml
@@ -19,38 +19,46 @@
   loop_control:
     label: "{{ item.0.key }}/{{ item.1 }}"
 
-- name: Down docker compose stacks
-  ansible.builtin.include_tasks: down.yml
-  loop: "{{ karo_compose_stacks_expanded | reverse }}"
-  loop_control:
-    label: "{{ item.name }}"
-  vars:
-    stack: "{{ item.name }}"
-    group: "{{ item.group }}"
-  when:
-    - lookup('vars', 'karo_compose_' ~ stack ~ '_enabled') | default(false)
-    - stack == karo_compose_justfile_stack or karo_compose_justfile_stack == 'all'
+- name: Down stacks
+  become: true
+  become_user: dockeruser
   tags: down
+  block:
+    - name: Down docker compose stacks
+      ansible.builtin.include_tasks: down.yml
+      loop: "{{ karo_compose_stacks_expanded | reverse }}"
+      loop_control:
+        label: "{{ item.name }}"
+      vars:
+        stack: "{{ item.name }}"
+        group: "{{ item.group }}"
+      when:
+        - lookup('vars', 'karo_compose_' ~ stack ~ '_enabled') | default(false)
+        - stack == karo_compose_justfile_stack or karo_compose_justfile_stack == 'all'
 
-- name: Deploy compose stacks
-  ansible.builtin.include_tasks: deploy.yml
-  loop: "{{ karo_compose_stacks_expanded }}"
-  loop_control:
-    label: "{{ item.name }}"
-  vars:
-    stack: "{{ item.name }}"
-    group: "{{ item.group }}"
-  when:
-    - lookup('vars', 'karo_compose_' ~ stack ~ '_enabled') | default(false)
-    - stack == karo_compose_justfile_stack or karo_compose_justfile_stack == 'all'
+- name: Deploy stacks
+  become: true
+  become_user: dockeruser
   tags: deploy
+  block:
+    - name: Deploy docker compose stacks
+      ansible.builtin.include_tasks: deploy.yml
+      loop: "{{ karo_compose_stacks_expanded }}"
+      loop_control:
+        label: "{{ item.name }}"
+      vars:
+        stack: "{{ item.name }}"
+        group: "{{ item.group }}"
+      when:
+        - lookup('vars', 'karo_compose_' ~ stack ~ '_enabled') | default(false)
+        - stack == karo_compose_justfile_stack or karo_compose_justfile_stack == 'all'
 
-- name: Create compose stacks
+- name: Create stacks
+  become: true
+  become_user: dockeruser
+  tags: up
   block:
     - name: Create tmpfs secrets directory
-      become: true
-      become_user: dockeruser
-      tags: up
       ansible.builtin.file:
         path: /run/user/1001/karo/compose
         state: directory
@@ -68,13 +76,9 @@
       when:
         - lookup('vars', 'karo_compose_' ~ stack ~ '_enabled') | default(false)
         - stack == karo_compose_justfile_stack or karo_compose_justfile_stack == 'all'
-      tags: up
 
   always:
     - name: Discard tmpfs secrets directory
-      become: true
-      become_user: dockeruser
-      tags: up
       ansible.builtin.file:
         path: "/run/user/1001/karo/compose"
         state: absent

--- a/roles/karo-compose/tasks/main.yml
+++ b/roles/karo-compose/tasks/main.yml
@@ -40,13 +40,34 @@
     - stack == karo_compose_justfile_stack or karo_compose_justfile_stack == 'all'
   tags: deploy
 
-- name: Up docker compose stacks
-  ansible.builtin.include_tasks: up.yml
-  loop: "{{ karo_compose_stacks_expanded }}"
-  vars:
-    stack: "{{ item.name }}"
-    group: "{{ item.group }}"
-  when:
-    - lookup('vars', 'karo_compose_' ~ stack ~ '_enabled') | default(false)
-    - stack == karo_compose_justfile_stack or karo_compose_justfile_stack == 'all'
-  tags: up
+- name: Create compose stacks
+  block:
+    - name: Create tmpfs secrets directory
+      become: true
+      become_user: dockeruser
+      tags: up
+      ansible.builtin.file:
+        path: /run/user/1001/karo/compose
+        state: directory
+        mode: "0700"
+
+    - name: Up docker compose stacks
+      ansible.builtin.include_tasks: up.yml
+      loop: "{{ karo_compose_stacks_expanded }}"
+      vars:
+        stack: "{{ item.name }}"
+        group: "{{ item.group }}"
+        secrets: "{{ lookup('vars', 'karo_compose_' ~ stack ~ '_secrets', default={}) | dict2items }}"
+      when:
+        - lookup('vars', 'karo_compose_' ~ stack ~ '_enabled') | default(false)
+        - stack == karo_compose_justfile_stack or karo_compose_justfile_stack == 'all'
+      tags: up
+
+  always:
+    - name: Discard tmpfs secrets directory
+      become: true
+      become_user: dockeruser
+      tags: up
+      ansible.builtin.file:
+        path: "/run/user/1001/karo/compose"
+        state: absent

--- a/roles/karo-compose/tasks/main.yml
+++ b/roles/karo-compose/tasks/main.yml
@@ -78,12 +78,6 @@
   become_user: dockeruser
   tags: up
   block:
-    - name: Create tmpfs secrets directory
-      ansible.builtin.file:
-        path: /run/user/1001/karo/compose
-        state: directory
-        mode: "0700"
-
     - name: Up docker compose stacks
       ansible.builtin.include_tasks: up.yml
       loop: "{{ karo_compose_stacks_expanded }}"
@@ -102,3 +96,4 @@
       ansible.builtin.file:
         path: "/run/user/1001/karo/compose"
         state: absent
+      when: secrets_dir | default(false)

--- a/roles/karo-compose/tasks/up.yml
+++ b/roles/karo-compose/tasks/up.yml
@@ -14,6 +14,7 @@
         path: /run/user/1001/karo/compose
         state: directory
         mode: "0700"
+      changed_when: false
 
     - name: Mark secrets directory as created
       ansible.builtin.set_fact:
@@ -28,6 +29,7 @@
   loop_control:
     loop_var: secret
     label: "{{ secret.key }}"
+  changed_when: false
 
 - name: Up compose stack {{ stack }}
   community.docker.docker_compose_v2:

--- a/roles/karo-compose/tasks/up.yml
+++ b/roles/karo-compose/tasks/up.yml
@@ -4,27 +4,23 @@
 
 ---
 
+- name: Create secrets for {{ stack }}
+  become: true
+  become_user: dockeruser
+  tags: up
+  ansible.builtin.copy:
+    dest: "/run/user/1001/karo/compose/{{ secret.key }}"
+    content: "{{ secret.value }}"
+    mode: "0644"
+  loop: "{{ secrets }}"
+  loop_control:
+    loop_var: secret
+    label: "{{ secret.key }}"
+
 - name: Up compose stack {{ stack }}
   become: true
   become_user: dockeruser
-  no_log: true
   tags: up
-  environment: # docker secrets
-    # pocketid
-    karo_compose_pocketid_encryption_key: "{{ karo_compose_pocketid_encryption_key if stack == 'pocketid' else '' }}"
-    karo_compose_pocketid_maxmind_license_key: "{{ karo_compose_pocketid_maxmind_license_key if stack == 'pocketid' else '' }}"
-    # traefik
-    karo_compose_traefik_acme_zone_api_token: "{{ karo_compose_traefik_acme_zone_api_token if stack == 'traefik' else '' }}"
-    karo_compose_traefik_acme_dns_api_token: "{{ karo_compose_traefik_acme_dns_api_token if stack == 'traefik' else '' }}"
-    karo_compose_traefik_tinyauth_oidc_client_secret: "{{ karo_compose_traefik_tinyauth_oidc_client_secret if stack == 'traefik' else '' }}"
-    # gluetun
-    karo_compose_gluetun_wireguard_config_raw: "{{ karo_compose_gluetun_wireguard_config_raw if stack == 'gluetun' else '' }}"
-    # godns
-    karo_compose_godns_dns_api_token: "{{ karo_compose_godns_dns_api_token if stack == 'godns' else '' }}"
-    # qbittorrent
-    karo_compose_qbittorrent_qui_session_secret: "{{ karo_compose_qbittorrent_qui_session_secret if stack == 'qbittorrent' else '' }}"
-    karo_compose_qbittorrent_qui_oidc_client_secret: "{{ karo_compose_qbittorrent_qui_oidc_client_secret if stack == 'qbittorrent' else '' }}"
-
   community.docker.docker_compose_v2:
     docker_host: unix:///run/user/1001/docker.sock
     project_src: "/srv/docker/{{ group }}/{{ stack }}"

--- a/roles/karo-compose/tasks/up.yml
+++ b/roles/karo-compose/tasks/up.yml
@@ -4,6 +4,21 @@
 
 ---
 
+- name: Prepare secrets
+  when:
+    - secrets | length > 0
+    - secrets_dir is undefined
+  block:
+    - name: Create tmpfs secrets directory
+      ansible.builtin.file:
+        path: /run/user/1001/karo/compose
+        state: directory
+        mode: "0700"
+
+    - name: Mark secrets directory as created
+      ansible.builtin.set_fact:
+        secrets_dir: true
+
 - name: Create secrets for {{ stack }}
   ansible.builtin.copy:
     dest: "/run/user/1001/karo/compose/{{ secret.key }}"

--- a/roles/karo-compose/tasks/up.yml
+++ b/roles/karo-compose/tasks/up.yml
@@ -5,9 +5,6 @@
 ---
 
 - name: Create secrets for {{ stack }}
-  become: true
-  become_user: dockeruser
-  tags: up
   ansible.builtin.copy:
     dest: "/run/user/1001/karo/compose/{{ secret.key }}"
     content: "{{ secret.value }}"
@@ -18,9 +15,6 @@
     label: "{{ secret.key }}"
 
 - name: Up compose stack {{ stack }}
-  become: true
-  become_user: dockeruser
-  tags: up
   community.docker.docker_compose_v2:
     docker_host: unix:///run/user/1001/docker.sock
     project_src: "/srv/docker/{{ group }}/{{ stack }}"

--- a/roles/karo-compose/templates/core/pocketid/compose.yml.j2
+++ b/roles/karo-compose/templates/core/pocketid/compose.yml.j2
@@ -27,16 +27,16 @@ services:
     environment:
       - LOG_LEVEL={{ karo_compose_pocketid_log_level }}
       - APP_URL={{ karo_compose_oidc_url }}
-      - ENCRYPTION_KEY_FILE=/run/secrets/karo_compose_pocketid_encryption_key
-      - MAXMIND_LICENSE_KEY_FILE=/run/secrets/karo_compose_pocketid_maxmind_license_key
+      - ENCRYPTION_KEY_FILE=/run/secrets/pocketid_encryption_key
+      - MAXMIND_LICENSE_KEY_FILE=/run/secrets/pocketid_maxmind_license_key
       - ANALYTICS_DISABLED=true
       - VERSION_CHECK_DISABLED=true
       - TRUST_PROXY=true
       - PUID=1000
       - PGID=1000
     secrets:
-      - karo_compose_pocketid_encryption_key
-      - karo_compose_pocketid_maxmind_license_key
+      - pocketid_encryption_key
+      - pocketid_maxmind_license_key
     healthcheck:
       test: [ "CMD", "/app/pocket-id", "healthcheck" ]
       interval: 1m30s
@@ -57,7 +57,7 @@ volumes:
     name: pocketid_data
 
 secrets:
-  karo_compose_pocketid_encryption_key:
-    environment: karo_compose_pocketid_encryption_key
-  karo_compose_pocketid_maxmind_license_key:
-    environment: karo_compose_pocketid_maxmind_license_key
+  pocketid_encryption_key:
+    file: /run/user/1001/karo/compose/pocketid_encryption_key
+  pocketid_maxmind_license_key:
+    file: /run/user/1001/karo/compose/pocketid_maxmind_license_key

--- a/roles/karo-compose/templates/core/traefik/compose.yml.j2
+++ b/roles/karo-compose/templates/core/traefik/compose.yml.j2
@@ -43,13 +43,13 @@ services:
       - tinyauth.apps.dashboard.oauth.groups={{ karo_compose_oidc_admin_group }}
 {% endif %}
     environment:
-      - CF_ZONE_API_TOKEN_FILE=/run/secrets/karo_compose_traefik_acme_zone_api_token
-      - CF_DNS_API_TOKEN_FILE=/run/secrets/karo_compose_traefik_acme_dns_api_token
+      - CF_ZONE_API_TOKEN_FILE=/run/secrets/traefik_acme_zone_api_token
+      - CF_DNS_API_TOKEN_FILE=/run/secrets/traefik_acme_dns_api_token
       - CLOUDFLARE_POLLING_INTERVAL=10
       - TZ={{ karo_compose_timezone }}
     secrets:
-      - karo_compose_traefik_acme_zone_api_token
-      - karo_compose_traefik_acme_dns_api_token
+      - traefik_acme_zone_api_token
+      - traefik_acme_dns_api_token
     depends_on:
       tinyauth:
         condition: service_healthy
@@ -83,7 +83,7 @@ services:
       - TINYAUTH_APPURL=https://{{ karo_compose_traefik_tinyauth_domain }}
       - TINYAUTH_OAUTH_AUTOREDIRECT=pocketid
       - TINYAUTH_OAUTH_PROVIDERS_POCKETID_CLIENTID={{ karo_compose_traefik_tinyauth_oidc_client_id }}
-      - TINYAUTH_OAUTH_PROVIDERS_POCKETID_CLIENTSECRETFILE=/run/secrets/karo_compose_traefik_tinyauth_oidc_client_secret
+      - TINYAUTH_OAUTH_PROVIDERS_POCKETID_CLIENTSECRETFILE=/run/secrets/tinyauth_oidc_client_secret
       - TINYAUTH_OAUTH_PROVIDERS_POCKETID_AUTHURL={{ karo_compose_oidc_authorization_url }}
       - TINYAUTH_OAUTH_PROVIDERS_POCKETID_TOKENURL={{ karo_compose_oidc_token_url }}
       - TINYAUTH_OAUTH_PROVIDERS_POCKETID_USERINFOURL={{ karo_compose_oidc_userinfo_url }}
@@ -92,7 +92,7 @@ services:
       - TINYAUTH_OAUTH_PROVIDERS_POCKETID_NAME={{ karo_compose_oidc_provider_name }}
       - DOCKER_HOST=tcp://cetusguard:2375
     secrets:
-      - karo_compose_traefik_tinyauth_oidc_client_secret
+      - tinyauth_oidc_client_secret
     depends_on:
       - cetusguard
 
@@ -148,9 +148,9 @@ volumes:
     name: traefik_acme
 
 secrets:
-  karo_compose_traefik_acme_zone_api_token:
-    environment: karo_compose_traefik_acme_zone_api_token
-  karo_compose_traefik_acme_dns_api_token:
-    environment: karo_compose_traefik_acme_dns_api_token
-  karo_compose_traefik_tinyauth_oidc_client_secret:
-    environment: karo_compose_traefik_tinyauth_oidc_client_secret
+  traefik_acme_zone_api_token:
+    file: /run/user/1001/karo/compose/traefik_acme_zone_api_token
+  traefik_acme_dns_api_token:
+    file: /run/user/1001/karo/compose/traefik_acme_dns_api_token
+  tinyauth_oidc_client_secret:
+    file: /run/user/1001/karo/compose/tinyauth_oidc_client_secret

--- a/roles/karo-compose/templates/extra/gluetun/compose.yml.j2
+++ b/roles/karo-compose/templates/extra/gluetun/compose.yml.j2
@@ -27,9 +27,9 @@ services:
       - VPN_SERVICE_PROVIDER=custom
       - VPN_TYPE=wireguard
       - FIREWALL_VPN_INPUT_PORTS={{ karo_compose_gluetun_firewall_vpn_input_ports }}
-      - WIREGUARD_CONF_SECRETFILE=/run/secrets/karo_compose_gluetun_wireguard_config_raw
+      - WIREGUARD_CONF_SECRETFILE=/run/secrets/gluetun_wireguard_config_raw
     secrets:
-      - karo_compose_gluetun_wireguard_config_raw
+      - gluetun_wireguard_config_raw
 
 networks:
   egress_gluetun:
@@ -40,5 +40,5 @@ networks:
     external: true
 
 secrets:
-  karo_compose_gluetun_wireguard_config_raw:
-    environment: karo_compose_gluetun_wireguard_config_raw
+  gluetun_wireguard_config_raw:
+    file: /run/user/1001/karo/compose/gluetun_wireguard_config_raw

--- a/roles/karo-compose/templates/extra/godns/compose.yml.j2
+++ b/roles/karo-compose/templates/extra/godns/compose.yml.j2
@@ -20,7 +20,7 @@ services:
         target: /config.json
         read_only: true
     secrets:
-      - karo_compose_godns_dns_api_token
+      - godns_dns_api_token
 
 networks:
   egress_godns:
@@ -29,5 +29,5 @@ networks:
     internal: false
 
 secrets:
-  karo_compose_godns_dns_api_token:
-    environment: karo_compose_godns_dns_api_token
+  godns_dns_api_token:
+    file: /run/user/1001/karo/compose/godns_dns_api_token

--- a/roles/karo-compose/templates/extra/godns/config.json.j2
+++ b/roles/karo-compose/templates/extra/godns/config.json.j2
@@ -1,7 +1,7 @@
 {
     "debug_info": {{ karo_compose_godns_debug_info_enabled | lower }},
     "provider": "Cloudflare",
-    "login_token_file": "/run/secrets/karo_compose_godns_dns_api_token",
+    "login_token_file": "/run/secrets/godns_dns_api_token",
     "domains": [
         {
         "domain_name": "{{ karo_compose_root_domain }}",

--- a/roles/karo-compose/templates/extra/qbittorrent/compose.yml.j2
+++ b/roles/karo-compose/templates/extra/qbittorrent/compose.yml.j2
@@ -54,16 +54,16 @@ services:
       - traefik.http.services.qui.loadbalancer.server.port=7476
     environment:
       - QUI__LOG_LEVEL={{ karo_compose_qbittorrent_qui_log_level | upper }}
-      - QUI__SESSION_SECRET_FILE=/run/secrets/karo_compose_qbittorrent_qui_session_secret
+      - QUI__SESSION_SECRET_FILE=/run/secrets/qui_session_secret
       - QUI__OIDC_ENABLED=true
       - QUI__OIDC_ISSUER={{ karo_compose_oidc_url }}
       - QUI__OIDC_CLIENT_ID={{ karo_compose_qbittorrent_qui_oidc_client_id }}
-      - QUI__OIDC_CLIENT_SECRET_FILE=/run/secrets/karo_compose_qbittorrent_qui_oidc_client_secret
+      - QUI__OIDC_CLIENT_SECRET_FILE=/run/secrets/qui_oidc_client_secret
       - QUI__OIDC_REDIRECT_URL=https://{{ karo_compose_qbittorrent_qui_domain }}/api/auth/oidc/callback
       - QUI__OIDC_DISABLE_BUILT_IN_LOGIN=true
     secrets:
-      - karo_compose_qbittorrent_qui_session_secret
-      - karo_compose_qbittorrent_qui_oidc_client_secret
+      - qui_session_secret
+      - qui_oidc_client_secret
     depends_on:
       - qbittorrent
 
@@ -74,7 +74,7 @@ volumes:
     name: qui_data
 
 secrets:
-  karo_compose_qbittorrent_qui_session_secret:
-    environment: karo_compose_qbittorrent_qui_session_secret
-  karo_compose_qbittorrent_qui_oidc_client_secret:
-    environment: karo_compose_qbittorrent_qui_oidc_client_secret
+  qui_session_secret:
+    file: /run/user/1001/karo/compose/qui_session_secret
+  qui_oidc_client_secret:
+    file: /run/user/1001/karo/compose/qui_oidc_client_secret

--- a/roles/karo-docker/tasks/main.yml
+++ b/roles/karo-docker/tasks/main.yml
@@ -23,13 +23,13 @@
       ansible.builtin.deb822_repository:
         name: "docker"
         types: deb
-        uris: "{{ item.url }}"
+        uris: "{{ docker_repo_url }}"
         suites: "{{ ansible_facts.distribution_release }}"
         components: "stable"
-        signed_by: "{{ item.url }}/gpg"
+        signed_by: "{{ docker_repo_url }}/gpg"
         state: "present"
-      with_items:
-        - url: https://download.docker.com/linux/debian
+      vars:
+        docker_repo_url: https://download.docker.com/linux/debian
 
     - name: Install docker packages
       ansible.builtin.apt:

--- a/roles/karo-docker/tasks/rootless.yml
+++ b/roles/karo-docker/tasks/rootless.yml
@@ -33,6 +33,8 @@
           mode: "0755"
         - dir: .config/docker
           mode: "0700"
+      loop_control:
+        label: "{{ item.dir }}"
 
     - name: Copy authorized_keys for dockeruser
       ansible.builtin.copy:

--- a/roles/karo-system/files/bash_logout
+++ b/roles/karo-system/files/bash_logout
@@ -9,4 +9,4 @@ fi
 # karo-stack
 
 # clean-up vault password on logout
-export P="/run/user/1000/karo-stack/vault_pass"; [ -e "$P" ] && shred -u "$P" >/dev/null 2>&1 || true
+export P="/run/user/1000/karo/ansible/vault_pass"; [ -e "$P" ] && shred -u "$P" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Description

This is a large PR, which primarily changes how secrets are handled when creating stacks. It also reworks large parts of the compose role itself. Bringing cleaner code and improved reliability.

Additionally, some of the changes made to the compose role inspired smaller related improvements elsewhere in the playbook.

## Changes

<!--- list out changes made --->

- Inject secrets dynamically using files instead of hardcoded environment variables.
- Add asserts for the compose role. Ensuring the user has setup Docker, and is using a valid stack name.
- Improve logging output when running the playbook. Especially with loops in the compose role.
- Simplify and deduplicate code.

And
- Standardise tmpfs directory paths (inline with the new path secrets files are created at).
- Avoid the need to input the system's become password when running the playbook.

## Notes

<!--- include any helpful information --->

- Closes #48.

## Checklist

- [x] Written documentation
- [x] Linked relevant issues
