### PR TITLE
Pre-release enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # karo-stack
 
-**An open-source toolkit to create a declarative Linux homeserver**
+**An open-source toolkit for creating a declarative Linux homeserver**
 
 [![GitHub Release](https://img.shields.io/github/v/release/hazzuk/karo-stack?display_name=tag&cacheSeconds=7200)](https://github.com/hazzuk/karo-stack/releases)
 [![License](https://img.shields.io/github/license/hazzuk/karo-stack.svg?cacheSeconds=604800)](https://github.com/hazzuk/karo-stack/blob/main/LICENSE)

--- a/debian/server/d-i/trixie/preseed.cfg
+++ b/debian/server/d-i/trixie/preseed.cfg
@@ -103,11 +103,11 @@ d-i finish-install/reboot_in_progress note
 ### - add public ssh key
 ### - force password reset
 d-i preseed/late_command string in-target /bin/bash -c "\
-    install -d -m 0755 -o karo -g karo \
+    install -d -m 0700 -o karo -g karo \
         /home/karo/.ssh \
         /home/karo/.local \
         /home/karo/.local/bin \
         /srv/karo && \
     echo '<key>' > /tmp/karo_key && \
-    install -m 0644 -o karo -g karo /tmp/karo_key /home/karo/.ssh/authorized_keys && \
+    install -m 0600 -o karo -g karo /tmp/karo_key /home/karo/.ssh/authorized_keys && \
     chage -d 0 karo"

--- a/debian/server/d-i/trixie/preseed.cfg
+++ b/debian/server/d-i/trixie/preseed.cfg
@@ -82,8 +82,10 @@ d-i pkgsel/run_tasksel boolean false
 # example tasksel options: standard, ssh-server, gnome-desktop, kde-desktop, lxqt-desktop, laptop
 ### pkgsel
 d-i pkgsel/include string chrony openssh-server acl parted rsync micro git curl wget btop tree man-db wireguard pipx
-### disable telemetry
+### disable debian telemetry
 popularity-contest popularity-contest/participate boolean false
+### disable ssh password authentication
+openssh-server openssh-server/password-authentication boolean false
 
 
 ## boot loader (b.4.12) `sudo tree /boot/efi`
@@ -96,17 +98,16 @@ d-i grub-installer/with_other_os boolean true
 d-i finish-install/reboot_in_progress note
 
 
-## ssh
-### disable password authentication
-openssh-server openssh-server/password-authentication boolean false
-### add authorized public key
+## late command (b.5.1)
+### - create directories
+### - add public ssh key
+### - force password reset
 d-i preseed/late_command string in-target /bin/bash -c "\
-    mkdir -p /home/karo/.ssh && \
-    echo '<key>' \
-    > /home/karo/.ssh/authorized_keys && \
-    chown -R karo:karo /home/karo/.ssh/ && \
-    chmod 755 /home/karo/.ssh/ && \
-    chmod 644 /home/karo/.ssh/authorized_keys && \
-    install -d -m 0775 -o karo -g karo /home/karo/.local/bin && \
-    install -d -m 0775 -o karo -g karo /srv/karo && \
+    install -d -m 0755 -o karo -g karo \
+        /home/karo/.ssh \
+        /home/karo/.local \
+        /home/karo/.local/bin \
+        /srv/karo && \
+    echo '<key>' > /tmp/karo_key && \
+    install -m 0644 -o karo -g karo /tmp/karo_key /home/karo/.ssh/authorized_keys && \
     chage -d 0 karo"

--- a/debian/server/d-i/trixie/preseed.cfg
+++ b/debian/server/d-i/trixie/preseed.cfg
@@ -81,7 +81,7 @@ d-i pkgsel/run_tasksel boolean false
 #tasksel tasksel/first multiselect standard
 # example tasksel options: standard, ssh-server, gnome-desktop, kde-desktop, lxqt-desktop, laptop
 ### pkgsel
-d-i pkgsel/include string chrony openssh-server ansible acl python3-debian just parted rsync micro git curl wget btop tree man-db wireguard
+d-i pkgsel/include string chrony openssh-server acl parted rsync micro git curl wget btop tree man-db wireguard pipx
 ### disable telemetry
 popularity-contest popularity-contest/participate boolean false
 
@@ -107,5 +107,6 @@ d-i preseed/late_command string in-target /bin/bash -c "\
     chown -R karo:karo /home/karo/.ssh/ && \
     chmod 755 /home/karo/.ssh/ && \
     chmod 644 /home/karo/.ssh/authorized_keys && \
+    install -d -m 0775 -o karo -g karo /home/karo/.local/bin && \
     install -d -m 0775 -o karo -g karo /srv/karo && \
     chage -d 0 karo"

--- a/debian/server/d-i/trixie/preseed.cfg
+++ b/debian/server/d-i/trixie/preseed.cfg
@@ -81,7 +81,7 @@ d-i pkgsel/run_tasksel boolean false
 #tasksel tasksel/first multiselect standard
 # example tasksel options: standard, ssh-server, gnome-desktop, kde-desktop, lxqt-desktop, laptop
 ### pkgsel
-d-i pkgsel/include string chrony openssh-server acl parted rsync micro git curl wget btop tree man-db wireguard pipx
+d-i pkgsel/include string acl btop chrony curl git man-db micro openssh-server parted pipx rsync tree wget wireguard
 ### disable debian telemetry
 popularity-contest popularity-contest/participate boolean false
 ### disable ssh password authentication

--- a/debian/server/d-i/trixie/preseed.cfg
+++ b/debian/server/d-i/trixie/preseed.cfg
@@ -61,10 +61,12 @@ d-i mirror/country string manual
 d-i mirror/http/hostname string deb.debian.org
 d-i mirror/http/directory string /debian
 d-i mirror/http/proxy string
-### install non-free
+### enable non-free
 d-i apt-setup/non-free-firmware boolean true
 d-i apt-setup/non-free boolean true
 d-i apt-setup/contrib boolean true
+### enable backports
+d-i apt-setup/services-select multiselect security, updates, backports
 ### disable source repositories
 d-i apt-setup/enable-source-repositories boolean false
 ### remove dvd installation image from sources.list

--- a/justfile
+++ b/justfile
@@ -39,7 +39,7 @@ _host-preseed platform:
 
 # Setup a system
 @install hostname='': _check-password
-    ansible-playbook run.yml --tags setup --limit "{{hostname}}"
+    ansible-playbook run.yml --tags install --limit "{{hostname}}"
 
 
 # compose

--- a/roles/karo-docker/tasks/rootless.yml
+++ b/roles/karo-docker/tasks/rootless.yml
@@ -30,7 +30,7 @@
         - dir: .ansible/tmp
           mode: "0700"
         - dir: .ssh
-          mode: "0755"
+          mode: "0700"
         - dir: .config/docker
           mode: "0700"
       loop_control:
@@ -41,7 +41,7 @@
         src: /home/karo/.ssh/authorized_keys
         remote_src: true
         dest: /home/dockeruser/.ssh/authorized_keys
-        mode: "0644"
+        mode: "0600"
         owner: dockeruser
         group: dockeruser
 

--- a/roles/karo-system/defaults/main.yml
+++ b/roles/karo-system/defaults/main.yml
@@ -7,8 +7,6 @@
 karo_system_packages:
   - chrony
   - acl
-  - python3-debian
-  - just
   - parted
   - rsync
   - micro
@@ -18,6 +16,7 @@ karo_system_packages:
   - tree
   - man-db
   - wireguard
+  - pipx
 
 karo_system_motd_raw: |
    _                           _             _    

--- a/roles/karo-system/defaults/main.yml
+++ b/roles/karo-system/defaults/main.yml
@@ -5,18 +5,20 @@
 ---
 
 karo_system_packages:
-  - chrony
   - acl
-  - parted
-  - rsync
-  - micro
-  - curl
-  - wget
   - btop
-  - tree
+  - chrony
+  - curl
+  # - git (managed by karo-git)
   - man-db
-  - wireguard
+  - micro
+  # - openssh-server (managed by karo-ssh)
+  - parted
   - pipx
+  - rsync
+  - tree
+  - wget
+  - wireguard
 
 karo_system_motd_raw: |
    _                           _             _    

--- a/roles/karo-system/tasks/main.yml
+++ b/roles/karo-system/tasks/main.yml
@@ -10,59 +10,65 @@
     mode: "0700"
     state: directory
 
-- name: Install essential packages
-  ansible.builtin.apt:
-    cache_valid_time: 86400
-    name: "{{ karo_system_packages }}"
-    state: present
+- name: Manage packages
+  block:
+    - name: Install essential packages
+      ansible.builtin.apt:
+        cache_valid_time: 86400
+        name: "{{ karo_system_packages }}"
+        state: present
 
-- name: Upgrade packages
-  ansible.builtin.apt:
-    update_cache: true
-    allow_downgrade: true
-    upgrade: true
+    - name: Upgrade packages
+      ansible.builtin.apt:
+        update_cache: true
+        allow_downgrade: true
+        upgrade: true
 
-- name: Configure kernel parameters
-  ansible.builtin.copy:
-    src: sysctl_karo.conf
-    dest: /etc/sysctl.d/karo.conf
-    mode: "0644"
-  notify: Reload sysctl config
+- name: Configure kernel
+  block:
+    - name: Set kernel parameters
+      ansible.builtin.copy:
+        src: sysctl_karo.conf
+        dest: /etc/sysctl.d/karo.conf
+        mode: "0644"
+      notify: Reload sysctl config
 
-- name: Load kernel modules
-  ansible.builtin.copy:
-    src: modules_karo.conf
-    dest: /etc/modules-load.d/karo.conf
-    mode: "0644"
-  notify: Restart systemd-modules-load
+    - name: Load kernel modules
+      ansible.builtin.copy:
+        src: modules_karo.conf
+        dest: /etc/modules-load.d/karo.conf
+        mode: "0644"
+      notify: Restart systemd-modules-load
 
-- name: Flush handlers
-  ansible.builtin.meta: flush_handlers
+    - name: Flush handlers
+      ansible.builtin.meta: flush_handlers
 
-- name: Set bash configuration for karo
-  ansible.builtin.copy:
-    src: "{{ item }}"
-    dest: "/home/karo/.{{ item }}"
-    mode: "0644"
-    owner: karo
-    group: karo
-  loop:
-    - bash_logout
-    - profile
+- name: Setup system
+  block:
+    - name: Set bash configuration for karo
+      ansible.builtin.copy:
+        src: "{{ item }}"
+        dest: "/home/karo/.{{ item }}"
+        mode: "0644"
+        owner: karo
+        group: karo
+      loop:
+        - bash_logout
+        - profile
 
-- name: Add hostname to hosts
-  ansible.builtin.lineinfile:
-    path: /etc/hosts
-    regexp: '^127\.0\.1\.1\s+debian(\s+{{ inventory_hostname }})?$'
-    line: "127.0.1.1 debian {{ inventory_hostname }}"
+    - name: Add hostname to hosts
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        regexp: '^127\.0\.1\.1\s+debian(\s+{{ inventory_hostname }})?$'
+        line: "127.0.1.1 debian {{ inventory_hostname }}"
 
-- name: Set system hostname
-  ansible.builtin.hostname:
-    name: "{{ inventory_hostname }}"
-    use: systemd
+    - name: Set system hostname
+      ansible.builtin.hostname:
+        name: "{{ inventory_hostname }}"
+        use: systemd
 
-- name: Set motd
-  ansible.builtin.copy:
-    content: "{{ karo_system_motd_raw }}"
-    dest: /etc/motd
-    mode: "0644"
+    - name: Set motd
+      ansible.builtin.copy:
+        content: "{{ karo_system_motd_raw }}"
+        dest: /etc/motd
+        mode: "0644"

--- a/roles/karo-system/tasks/main.yml
+++ b/roles/karo-system/tasks/main.yml
@@ -36,6 +36,9 @@
     mode: "0644"
   notify: Restart systemd-modules-load
 
+- name: Flush handlers
+  ansible.builtin.meta: flush_handlers
+
 - name: Set bash configuration for karo
   ansible.builtin.copy:
     src: "{{ item }}"

--- a/run.yml
+++ b/run.yml
@@ -9,8 +9,8 @@
   become: true
   tags: install
   roles:
-    - karo-nftables
     - karo-system
+    - karo-nftables
     - karo-ssh
     - karo-git
     - karo-docker

--- a/run.yml
+++ b/run.yml
@@ -4,10 +4,10 @@
 
 ---
 
-- name: Provision karo-stack debian server
+- name: Manage system setup
   hosts: server
   become: true
-  tags: setup
+  tags: install
   roles:
     - karo-nftables
     - karo-system
@@ -15,7 +15,7 @@
     - karo-git
     - karo-docker
 
-- name: Manage karo-stack docker compose
+- name: Manage compose stacks
   hosts: server
   become: true
   tags: compose


### PR DESCRIPTION
## Description

<!--- include a brief summary of this pr --->

This PR includes numerous small changes and fixes made following a period of end-to-end testing. All in preparation for a new release, and subsequent usage by new users.

## Changes

<!--- list out changes made --->

- Fixed kernel module `br_netfilter` not loaded before the playbook runs the Docker setup role.
- Enabled Debian backports apt source in preseed (for future use).
- Use the Python package manager `pipx` to install `ansible` and `just` packages.
- Additional miscellaneous changes.

## Notes

<!--- include any helpful information --->

While both Ansible and just were available as apt packages. Due to the nature of Debian, these packages are now woefully outdated. Alongside Docker, these packages make up the core technologies used by the project. As such, they are both now installed via a 3rd-party package manager, with the latest releases readily available.

[`pipx`](https://pipx.pypa.io/stable/reference/cli/#pipx-install) was selected as it's the [officially supported](https://docs.ansible.com/projects/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pipx) install method for Ansible. And as Ansible already requires Python be installed, using a Python package manager reduces any further required package installs (e.g. installing rust-just with Cargo, the Rust package manager, would require over a gigabyte in new packages). 

## Checklist

- [x] Written documentation
- [n/a] Linked relevant issues
