### PR TITLE
Minor stack tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 **An open-source toolkit for creating a declarative Linux homeserver**
 
 [![GitHub Release](https://img.shields.io/github/v/release/hazzuk/karo-stack?display_name=tag&cacheSeconds=7200)](https://github.com/hazzuk/karo-stack/releases)
-[![License](https://img.shields.io/github/license/hazzuk/karo-stack.svg?cacheSeconds=604800)](https://github.com/hazzuk/karo-stack/blob/main/LICENSE)
+[![License](https://img.shields.io/badge/license-AGPL--3.0-orange)](https://github.com/hazzuk/karo-stack/blob/main/LICENSE)
 [![GitHub repo size](https://img.shields.io/github/repo-size/hazzuk/karo-stack?cacheSeconds=604800)](https://github.com/hazzuk/karo-stack)
 
 [![Developed by Humans, Not by AI](not-by-ai.png)](https://notbyai.fyi/)

--- a/debian/server/d-i/trixie/preseed.cfg
+++ b/debian/server/d-i/trixie/preseed.cfg
@@ -108,6 +108,7 @@ d-i preseed/late_command string in-target /bin/bash -c "\
         /home/karo/.local \
         /home/karo/.local/bin \
         /srv/karo && \
-    echo '<key>' > /tmp/karo_key && \
+    echo '<key>' \
+        > /tmp/karo_key && \
     install -m 0600 -o karo -g karo /tmp/karo_key /home/karo/.ssh/authorized_keys && \
     chage -d 0 karo"

--- a/roles/karo-compose/templates/core/traefik/compose.yml.j2
+++ b/roles/karo-compose/templates/core/traefik/compose.yml.j2
@@ -4,6 +4,7 @@
 
 # https://docs.karolabs.dev/stacks/core/traefik
 
+{% set traefik_acme_volume = "traefik_acme_staging" if karo_compose_traefik_acme_staging_enabled else "traefik_acme" %}
 ---
 name: traefik
 services:
@@ -29,7 +30,7 @@ services:
         target: /etc/traefik/traefik.yml
         read_only: true
       - type: volume
-        source: traefik_acme
+        source: {{ traefik_acme_volume }}
         target: /etc/traefik/acme
     labels:
       - traefik.enable=true
@@ -144,8 +145,8 @@ networks:
           gateway: 172.18.0.1
 
 volumes:
-  traefik_acme:
-    name: traefik_acme
+  {{ traefik_acme_volume }}:
+    name: {{ traefik_acme_volume }}
 
 secrets:
   traefik_acme_zone_api_token:

--- a/roles/karo-compose/templates/extra/jellyfin/compose.yml.j2
+++ b/roles/karo-compose/templates/extra/jellyfin/compose.yml.j2
@@ -12,8 +12,6 @@ services:
     image: {{ karo_compose_jellyfin_image }}:{{ karo_compose_jellyfin_version }}
     container_name: jellyfin
     restart: {{ karo_compose_restart_policy }}
-    ports:
-      - "0.0.0.0:7359:7359/udp" # client discovery
     networks:
       - egress_jellyfin
       - frontend

--- a/roles/karo-nftables/templates/nftables.conf.j2
+++ b/roles/karo-nftables/templates/nftables.conf.j2
@@ -37,11 +37,6 @@ table inet filter {
                 udp dport 443 accept
 {% endif %}
 
-{% if karo_compose_jellyfin_enabled | default(false) %}
-
-                # allow jellyfin discovery port
-                udp dport 7359 accept
-{% endif %}
 {% if karo_compose_proxy_client_enabled | default(false) %}
 
                 # allow wireguard proxyserver traffic


### PR DESCRIPTION
## Description

<!--- include a brief summary of this pr --->

Small changes to the Jellyfin and Traefik stacks (based on recent user testing).

## Changes

<!--- list out changes made --->

- Traefik now uses either a live or staging volume (based on `karo_compose_traefik_acme_staging_enabled`).
- Jellyfin no longer exposes its client discovery port.

## Notes

<!--- include any helpful information --->

- The Jellyfin client discovery port was always very unreliable during testing across different Jellyfin clients.
- Ahead of custom stacks, was important to remove any stack specific customisation inside the nftables config.

## Checklist

- [n/a] Written documentation
- [n/a] Linked relevant issues
