### PR TITLE
Add GitHub templates

### DIFF
--- a/.github/DISCUSSION_TEMPLATE/ideas.yml
+++ b/.github/DISCUSSION_TEMPLATE/ideas.yml
@@ -1,0 +1,36 @@
+body:
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      description: Take a couple minutes to help the maintainers work faster.
+      options:
+        - label: I have searched existing and closed discussions
+          required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Provide detailed information on what you'd like to see added, please be sure to include as much detail as possible and any related resources.
+      placeholder: "Describe the proposed feature or enhancement."
+    validations:
+      required: true
+
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Describe why this change is needed or would be helpful, and what problems it could solve.
+      placeholder: "Explain the reasons behind the proposal."
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: If applicable, add any additional details or relevant information.
+      placeholder: "Add any extra information."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,60 @@
+name: Report a bug
+description: Describe a bug or issue you have identified
+labels: ["Kind/Bug"]
+assignees:
+  - hazzuk
+
+body:
+  - type: checkboxes
+    id: prerequisites
+    attributes:
+      label: Prerequisites
+      description: Take a couple minutes to help the maintainers work faster.
+      options:
+        - label: I have searched existing and closed issues
+          required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: What version are you using?
+      description: Specify the version of the software in which the bug occurs.
+      placeholder: "e.g. 1.0.0"
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: Describe what you expected to happen.
+      placeholder: "What should normally happen?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: Describe what actually happened.
+      placeholder: "What happened instead?"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the issue
+      description: Explain what's happening, steps to reproduce it and any screenshots.
+      placeholder: "Provide a step by step description of the bug."
+    validations:
+      required: true
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Any additional notes
+      description: Highlight important context, possible solutions or any extra details.
+      placeholder: "Include context and observations."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,10 @@
+blank_issues_enabled: false
+
+contact_links:
+  - name: Suggest a feature
+    url: https://github.com/hazzuk/karo-stack/discussions/new?category=ideas
+    about: Propose an improvement, request a change, or discuss an idea
+
+  - name: Ask a question
+    url: https://github.com/hazzuk/karo-stack/discussions/new?category=q-a
+    about: Get help, seek clarification, or ask about the project


### PR DESCRIPTION
## Description

<!--- include a brief summary of this pr --->

The repo will now use GitHub discussions to help manage feature requests and general discourse. GitHub issues will solely be used for bugs. This follows [a similar approach used by other projects](https://www.11ty.dev/blog/github-issues/#leaning-into-git-hub-discussions). 

This PR implements a bug report and ideas template (based on [previously used templates](https://github.com/hazzuk/.github)). Along with a template chooser config.