### PR TITLE
Compose task names and variables

### DIFF
--- a/roles/karo-compose/tasks/main.yml
+++ b/roles/karo-compose/tasks/main.yml
@@ -98,7 +98,7 @@
         loop_var: stack
         label: "{{ stack.name }}"
       vars:
-        stack_vars: "{{ lookup('vars', stack.namespace ~ '_stack') }}"
+        stack_host_vars: "{{ lookup('vars', stack.namespace ~ '_stack') }}"
         stack_defaults: "{{ lookup('vars', stack.namespace ~ '_stack_defaults') }}"
         stack_secrets: "{{ query('filetree', '../templates/' ~ stack.path ~ '/secrets') }}"
         karo_compose_secrets_path: "/run/user/1001/karo-compose/{{ stack.path }}"

--- a/roles/karo-compose/tasks/main.yml
+++ b/roles/karo-compose/tasks/main.yml
@@ -19,7 +19,7 @@
     fail_msg: "Docker directory not present, run `just install` to setup Docker."
     quiet: true
 
-- name: Assert stack group names
+- name: Assert defined stack group names
   ansible.builtin.assert:
     that:
       - stack_group_lookup is not false
@@ -33,7 +33,7 @@
   vars:
     stack_group_lookup: "{{ lookup('vars', stack_group, default=false) }}"
 
-- name: Assert imported stack groups
+- name: Assert symlinked stack groups declared
   ansible.builtin.assert:
     that: stack_group_dir.path in karo_compose_stack_groups
     fail_msg: "Stack group '{{ stack_group_dir.path }}' missing from 'karo_compose_stack_groups'."
@@ -60,7 +60,7 @@
       {% endfor %}
       {{ expanded_stacks }}
 
-- name: Assert provided stack name
+- name: Assert supplied stack name
   ansible.builtin.assert:
     that: karo_compose_justfile_stack in (
         karo_compose_expanded_stacks | map(attribute='name') | list
@@ -76,7 +76,7 @@
   become_user: dockeruser
   tags: down
   block:
-    - name: Down docker compose stacks
+    - name: Down compose stacks
       ansible.builtin.include_tasks: down.yml
       loop: "{{ karo_compose_expanded_stacks | reverse }}"
       loop_control:
@@ -91,7 +91,7 @@
   become_user: dockeruser
   tags: up
   block:
-    - name: Up docker compose stacks
+    - name: Up compose stacks
       ansible.builtin.include_tasks: up.yml
       loop: "{{ karo_compose_expanded_stacks }}"
       loop_control:

--- a/roles/karo-compose/tasks/main.yml
+++ b/roles/karo-compose/tasks/main.yml
@@ -6,7 +6,7 @@
 
 ---
 
-# Setup
+# setup
 
 - name: Register docker directory status
   ansible.builtin.stat:
@@ -69,7 +69,7 @@
     fail_msg: "Invalid stack name '{{ karo_compose_justfile_stack }}'."
     quiet: true
 
-# Actions
+# actions
 
 - name: Down stacks
   become: true

--- a/roles/karo-compose/tasks/up.yml
+++ b/roles/karo-compose/tasks/up.yml
@@ -4,7 +4,7 @@
 
 ---
 
-# deploy templates
+# templates
 
 - name: "Create compose stack directory for {{ stack.name }}"
   ansible.builtin.file:
@@ -26,7 +26,7 @@
     loop_var: template
     label: "{{ template.path }}"
 
-# handle secrets
+# secrets
 
 - name: Prepare secrets
   when: stack_secrets | length > 0
@@ -55,7 +55,7 @@
         label: "{{ secret.path | splitext | first }}"
       changed_when: false
 
-# start services
+# services
 
 - name: Up compose stack {{ stack.name }}
   community.docker.docker_compose_v2:

--- a/roles/karo-compose/tasks/up.yml
+++ b/roles/karo-compose/tasks/up.yml
@@ -14,7 +14,7 @@
 
 - name: "Merge compose variables for {{ stack.name }}"
   ansible.builtin.set_fact:
-    compose: "{{ stack_defaults | combine(stack_host_vars, recursive=true) }}"
+    stack_vars: "{{ stack_defaults | combine(stack_host_vars, recursive=true) }}"
 
 - name: "Deploy compose templates for {{ stack.name }}"
   ansible.builtin.template:

--- a/roles/karo-compose/tasks/up.yml
+++ b/roles/karo-compose/tasks/up.yml
@@ -6,17 +6,17 @@
 
 # templates
 
-- name: "Create compose stack directory for {{ stack.name }}"
+- name: "Create directory for {{ stack.name }}"
   ansible.builtin.file:
     path: "/srv/docker/{{ stack.path }}"
     mode: "0774"
     state: directory
 
-- name: "Merge compose variables for {{ stack.name }}"
+- name: "Merge stack variables for {{ stack.name }}"
   ansible.builtin.set_fact:
     stack_vars: "{{ stack_defaults | combine(stack_host_vars, recursive=true) }}"
 
-- name: "Deploy compose templates for {{ stack.name }}"
+- name: "Render templates for {{ stack.name }}"
   ansible.builtin.template:
     src: "{{ template.src }}"
     dest: "/srv/docker/{{ stack.path }}/{{ template.path | splitext | first }}"
@@ -28,7 +28,7 @@
 
 # secrets
 
-- name: Prepare secrets
+- name: Handle secrets
   when: stack_secrets | length > 0
   block:
     - name: Create tmpfs secrets directory

--- a/roles/karo-compose/tasks/up.yml
+++ b/roles/karo-compose/tasks/up.yml
@@ -14,7 +14,7 @@
 
 - name: "Merge compose variables for {{ stack.name }}"
   ansible.builtin.set_fact:
-    compose: "{{ stack_defaults | combine(stack_vars, recursive=true) }}"
+    compose: "{{ stack_defaults | combine(stack_host_vars, recursive=true) }}"
 
 - name: "Deploy compose templates for {{ stack.name }}"
   ansible.builtin.template:


### PR DESCRIPTION
## Description

<!--- include a brief summary of this pr --->

General improvements to karo-compose task names, comments, and variables.

Importantly, also renames the combined stack dictionary from `compose` to `stack_vars`.

## Notes

<!--- include any helpful information --->

Custom stacks will now need to use the `stack_vars` dictionary, e.g.

```yaml
{{ stack_vars.traefik.log_level }}
```

## Checklist

- [x] Written documentation
- [x] Linked relevant issues
