### PR TITLE
Docker secrets in stack_vars

### DIFF
--- a/roles/karo-compose/tasks/main.yml
+++ b/roles/karo-compose/tasks/main.yml
@@ -100,7 +100,6 @@
       vars:
         stack_host_vars: "{{ lookup('vars', stack.namespace ~ '_stack', default={}) }}"
         stack_defaults: "{{ lookup('vars', stack.namespace ~ '_stack_defaults') }}"
-        stack_secrets: "{{ query('filetree', '../templates/' ~ stack.path ~ '/secrets') }}"
         karo_compose_secrets_path: "/run/user/1001/karo-compose/{{ stack.path }}"
       when:
         - stack.enabled

--- a/roles/karo-compose/tasks/up.yml
+++ b/roles/karo-compose/tasks/up.yml
@@ -36,6 +36,22 @@
 
 # secrets
 
+- name: Find stack secrets for {{ stack.name }}
+  ansible.builtin.set_fact:
+    stack_secrets: |
+      {% set secrets = [] %}
+      {% for service in stack_vars.values() %}
+      {%   if service.secrets is defined %}
+      {%     for secret in service.secrets %}
+      {%       set _ = secrets.append({
+                  'name': secret,
+                  'value': service.secrets[secret]
+                }) %}
+      {%     endfor %}
+      {%   endif %}
+      {% endfor %}
+      {{ secrets }}
+
 - name: Handle secrets
   when: stack_secrets | length > 0
   block:

--- a/roles/karo-compose/tasks/up.yml
+++ b/roles/karo-compose/tasks/up.yml
@@ -36,16 +36,16 @@
 
 # secrets
 
-- name: Find stack secrets for {{ stack.name }}
+- name: Gather stack secrets for {{ stack.name }}
   ansible.builtin.set_fact:
     stack_secrets: |
       {% set secrets = [] %}
-      {% for service in stack_vars.values() %}
-      {%   if service.secrets is defined %}
-      {%     for secret in service.secrets %}
+      {% for service_name, service_vars in stack_vars.items() %}
+      {%   if service_vars.secrets is defined %}
+      {%     for secret_name, secret_value in service_vars.secrets.items() %}
       {%       set _ = secrets.append({
-                  'name': secret,
-                  'value': service.secrets[secret]
+                  'name': service_name ~ '_' ~ secret_name,
+                  'value': secret_value
                 }) %}
       {%     endfor %}
       {%   endif %}

--- a/roles/karo-compose/tasks/up.yml
+++ b/roles/karo-compose/tasks/up.yml
@@ -29,7 +29,7 @@
     src: "{{ template.src }}"
     dest: "/srv/docker/{{ stack.path }}/{{ template.path | splitext | first }}"
     mode: "0644"
-  loop: "{{ query('filetree', '../templates/' ~ stack.path, exclude='^secrets$') }}"
+  loop: "{{ query('filetree', '../templates/' ~ stack.path) }}"
   loop_control:
     loop_var: template
     label: "{{ template.path }}"
@@ -69,14 +69,13 @@
 
     - name: Create secrets for {{ stack.name }}
       ansible.builtin.copy:
-        # secrets template, removing end of file newline
-        content: "{{ lookup('template', secret.src) | regex_replace('(\r?\n)$', '') }}"
-        dest: "{{ karo_compose_secrets_path }}/{{ secret.path | splitext | first }}"
+        content: "{{ secret.value }}"
+        dest: "{{ karo_compose_secrets_path }}/{{ secret.name }}"
         mode: "0644"
       loop: "{{ stack_secrets }}"
       loop_control:
         loop_var: secret
-        label: "{{ secret.path | splitext | first }}"
+        label: "{{ secret.name }}"
       changed_when: false
 
 # services


### PR DESCRIPTION
## Description

<!--- include a brief summary of this pr --->

Based on https://github.com/hazzuk/karo-stack/pull/80#issuecomment-5245711962.

Removes the need to create secrets templates. Instead, variables are now marked as secrets inside a stack's dictionary. Helping to reduce complexity and maintenance of custom stacks. 

## Notes

<!--- include any helpful information --->

- Stack example:

  ```yaml
  example_group_foobar_stack:
    foobar:
      domain: "foobar.{{ karo_compose_root_domain }}"
      log_level: info
      secrets: # nested secrets dictionary
        api_token: "xP5SDH57+zn4hR804VFN#p=="
  ```

- #80 will still be merged, as it provides foundational work this PR builds upon.
- Docs have been updated to account for this change: https://docs.karolabs.dev/dev/compose/secrets/

## Checklist

- [x] Written documentation
- [x] Linked relevant issues
